### PR TITLE
Ajustes no teste rest de controller e rest external

### DIFF
--- a/test/graphql/external/checkoutExternalGraphQl.test.js
+++ b/test/graphql/external/checkoutExternalGraphQl.test.js
@@ -18,7 +18,7 @@ describe('Teste de checkout', () => {
         chekoutSucesso = require('../fixture/requisicoes/checkout/chekoutComSucesso.json');
     });
 
-    it('Teste de chekout com pagamento via cartão de crédito', async () => {
+    it('Teste de checkout com pagamento via cartão de crédito', async () => {
         respostaEsperada = require('../fixture/respostas/validarCheckoutComSucesso.json');
         const respostaCheckout = await request(process.env.BASE_URL_GRAPHQL)
             .post('')

--- a/test/rest/controller/checkoutController.test.js
+++ b/test/rest/controller/checkoutController.test.js
@@ -56,13 +56,15 @@ describe('Checkout Controller', () => {
                 ],
                 freight: 0,
                 paymentMethod: "boleto",
-                total: 190
+                total: 200
             });
             const resposta = await request(app)
                 .post('/api/checkout')
                 .set('Authorization', `Bearer ${token}`)
                 .send(postChekoutSucesso);
             respostaEsperada.paymentMethod = "boleto";
+            respostaEsperada.total = 200;
+            respostaEsperada.valorFinal = 200;
             expect(resposta.body).to.deep.equal(respostaEsperada);
             expect(resposta.status).to.equal(200);
         });

--- a/test/rest/external/checkoutExternal.test.js
+++ b/test/rest/external/checkoutExternal.test.js
@@ -12,15 +12,17 @@ describe('Checkout External', () => {
                 .send(postLogin);
             this.token = respostaLogin.body.token;
         });
-        it('Quando envio dados válidos no checkout com pagmento via cartão de crédito, recebo uma resposta 200', async function () {
+
+        it('Quando envio dados válidos no checkout com pagamento via cartão de crédito, recebo uma resposta 200', async function () {
             const postChekoutSucesso = require('../fixture/requisicoes/checkout/postChekoutSucesso.json');
             const respostaEsperada = require('../fixture/respostas/checkout/quandoEnvioDadosValidosNoCheckoutReceboUmaResposta200.json');
             const resposta = await request(process.env.BASE_URL_REST)
                 .post('/api/checkout')
                 .set('Authorization', `Bearer ${this.token}`)
                 .send(postChekoutSucesso);
-            // Ajuste para garantir que o campo paymentMethod seja igual ao retornado
             respostaEsperada.paymentMethod = resposta.body.paymentMethod;
+            respostaEsperada.total = resposta.body.total;
+            respostaEsperada.valorFinal = resposta.body.valorFinal;
             expect(resposta.body).to.deep.equal(respostaEsperada);
             expect(resposta.status).to.equal(200);
         });

--- a/test/rest/external/checkoutExternal.test.js
+++ b/test/rest/external/checkoutExternal.test.js
@@ -20,9 +20,6 @@ describe('Checkout External', () => {
                 .post('/api/checkout')
                 .set('Authorization', `Bearer ${this.token}`)
                 .send(postChekoutSucesso);
-            respostaEsperada.paymentMethod = resposta.body.paymentMethod;
-            respostaEsperada.total = resposta.body.total;
-            respostaEsperada.valorFinal = resposta.body.valorFinal;
             expect(resposta.body).to.deep.equal(respostaEsperada);
             expect(resposta.status).to.equal(200);
         });


### PR DESCRIPTION
Foi identificado erro na validação do teste no valor do checkout de boleto, pois, eu estava passando considerando o desconto de 5% sendo que  a regra se aplica apenas ao checkkout de cartão de crédito. Além disso, ao executar os testes com  "npm test" foi identificado uma divergencia dos valores na validação. 